### PR TITLE
Make the go mod as other repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cloudtrust/common-healthcheck
 
-go 1.23
-
-toolchain go1.24.3
+go 1.24.1
 
 require (
 	github.com/go-kit/kit v0.13.0


### PR DESCRIPTION
Avoid those kind of PRs : https://github.com/cloudtrust/common-healthcheck/pull/15

And also align with all other repos we have.